### PR TITLE
MELPA is now HTTPS

### DIFF
--- a/lib/packages.el
+++ b/lib/packages.el
@@ -38,7 +38,7 @@
 (setq package-archives '(
                           ("gnu" . "https://elpa.gnu.org/packages/")
                           ("marmalade" . "https://marmalade-repo.org/packages/")
-                          ;; ("melpa" . "http://melpa.org/packages/") ;; Not HTTPS, not signed (yet).
+                          ("melpa" . "https://melpa.org/packages/")
                           ))
 
 (defun packages-installed-p ()


### PR DESCRIPTION
- Re-enable melpa as it's now avail over https.
